### PR TITLE
add vsphere-env.sh template 

### DIFF
--- a/vSphere/README.md
+++ b/vSphere/README.md
@@ -20,11 +20,9 @@ The purpose for this is cleaning up lab environments.  It's meant to be run by C
 
 ## Usage
 
-To run it manually with Docker:
+Edit the ./env.sh 
 
 ```
-docker run -it -v $(pwd):/the-cleaner -w /the-cleaner ubuntu /bin/bash
-./setup.sh
 export GOVC_URL='https://<vsphere-url>'
 export GOVC_INSECURE=1
 export GOVC_PERSIST_SESSION=1
@@ -34,5 +32,17 @@ export GOVC_PASSWORD='pass'
 export GOVC_DATACENTER='Datacenter'
 export GOVC_CLUSTER='Cluster'
 export GOVC_DATASTORE='Datastore'
+```
+
+Using Docer to execute the clenanup
+
+```
+docker run -it -v $(pwd):/the-cleaner -w /the-cleaner ubuntu /bin/bash
+./setup.sh
+```
+
+Execute the cleanup
+
+```
 ./run.sh
 ```

--- a/vSphere/run.sh
+++ b/vSphere/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source ./vsphere-env.sh
+
 if [ "" == "$ENV" ]; then
     echo 'You must set environment variable ENV to the environment number to clean'
     exit -1

--- a/vSphere/vsphere-env.sh
+++ b/vSphere/vsphere-env.sh
@@ -1,0 +1,9 @@
+export GOVC_URL='https://<vsphere-url>'
+export GOVC_INSECURE=1
+export GOVC_PERSIST_SESSION=1
+export ENV=<two digit env number>
+export GOVC_USERNAME="user"
+export GOVC_PASSWORD='pass'
+export GOVC_DATACENTER='Datacenter'
+export GOVC_CLUSTER='Cluster'
+export GOVC_DATASTORE='Datastore'


### PR DESCRIPTION
allows users to simply fill out an env template instead of copy pasting exports which can lead to common user mistakes 


```
root@c9dc5121ec1b:/the-cleaner# ./run.sh
./vsphere-env.sh: line 4: syntax error near unexpected token `newline'
```