### PR TITLE
fix azure cloud cleaner scripts as ubuntu xenial is not supported

### DIFF
--- a/Azure/README.md
+++ b/Azure/README.md
@@ -26,11 +26,11 @@ The purpose for this is cleaning up lab environments.  It's meant to be run by C
 
 To run it manually with Docker:
 
+Note: You can get the `AZURE_TENANT` from command "azure account list"
+
 ```
-docker run -it -v $(pwd):/the-cleaner -w /the-cleaner ubuntu /bin/bash
+docker run -it -v $(pwd):/the-cleaner -w /the-cleaner ubuntu:14.04 /bin/bash
 ./setup.sh
-export AZURE_USER=<your-service-user>
-export AZURE_PASSWORD=<your-service-pass>
 export AZURE_TENANT=<your-account-email>
 ./run.sh
 ```

--- a/Azure/run.sh
+++ b/Azure/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-az login --service-principal -u "$AZURE_USER" --password "$AZURE_PASSWORD" --tenant "$AZURE_TENANT"
+az login --tenant "$AZURE_TENANT"
 
 VMS=$(az vm list | jq -r '.[].id')
 echo "Cleaning up VMs..."

--- a/Azure/setup.sh
+++ b/Azure/setup.sh
@@ -5,4 +5,4 @@ apt-get update && apt-get install -y jq
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | tee /etc/apt/sources.list.d/azure-cli.list
 apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
 apt-get install -y apt-transport-https
-apt-get update && apt-get install -y azure-cli
+apt-get update && apt-get install -y --force-yes azure-cli


### PR DESCRIPTION

 using `docker run` with ubutnu:latest will deploy the latest `xenial` release by default if you do not have a ubuntu image cached on your laptop.  This generally will impact new users installing docker for the first time.  Xenial will not allow apt-get to run because the microsoft repo ssl certs are not trusted and the gpg key fails to install. 

this PR will get the azure cloud cleaner working with ubuntu trusty.  But i think later we need to resolve how azure cli get installed so we can eventually use the latest ubuntu package. 


Additionally we were not able to run the scripts with a username/password.  We resolved this by editing the run.sh to use the SSO auth method.
